### PR TITLE
Fix cont cdf

### DIFF
--- a/Example.R
+++ b/Example.R
@@ -139,7 +139,7 @@ lines(x,cdf(x),lty=2,col=2)
 cdf <- contCDF(quantiles = test1$gbm_mqr[index,],kfold = NA,method = "spline", tails=list(method="exponential",L=0,U=1,nBins=5,preds=test1$gbm_mqr,targetvar=test1$data$TARGETVAR,ntailpoints=25))
 lines(x,cdf(seq(0,1,by=0.001)),lty=3,col=4)
 cdf <- contCDF(quantiles = test1$gbm_mqr[index,],method = "spline", tails=list(method="dyn_exponential",ntailpoints=25))
-lines(quants,cdf(quants),lty=4,col=5)
+lines(x,cdf(x),lty=4,col=5)
 points(test1$gbm_mqr[index,],as.numeric(gsub("q","",colnames(test1$gbm_mqr[index,])))/100)
 legend(0.01,1,c("Predicted Quantiles","Linear","Spline","Spline with Exponential Tails"),
        pch=c(1,NA,NA,NA),lty=c(NA,2,1,3),col=c(1,2,1,4),bty="n")
@@ -219,7 +219,7 @@ for (i in levels(unique(u_obsind$kfold))){
 }
 
 
-## method for parametric pred dist.
+## method for gbm pred dist.
 scen_gbm <- samps_to_scens(copulatype = "temporal",no_samps = f_nsamp,marginals = list(loc_1 = test1$gbm_mqr),sigma_kf = cvm_gbm,mean_kf = mean_list,
                            control=list(loc_1 = list(kfold = u_obsind$kfold,issue_ind=u_obsind$i_time,horiz_ind=u_obsind$lead_time,
                                                      PIT_method="spline",

--- a/R/PIT.R
+++ b/R/PIT.R
@@ -21,6 +21,7 @@ PIT <- function(distdata,...) {
 #' @param qrdata A \code{MultiQR} object.
 #' @param obs A vector of observations corresponding to the rows of \code{qrdata}.
 #' @param tails A list of arguments passed to \code{condCDF} defining the tails of the CDFs.
+#' See \code{?contCDF} for details.
 #' Tail parameters my have length 1 or length \code{nrow(qrdata)} if each row of qrdata
 #' has a corresponding parameter value.
 #' @param inverse A \code{boolean}. If true, the inverse transformation is appiled, i.e. uniform variable
@@ -33,27 +34,12 @@ PIT <- function(distdata,...) {
 #' @export
 PIT.MultiQR <- function(qrdata,obs,tails,inverse=FALSE,...){
   
-  # if(length(obs)!=nrow(qrdata)){stop("length(obs)!=nrow(qrdata)")}
-  
-  if(tails$method=="exponential" & is.null(tails$thicknessPL) & is.null(tails$thicknessPR)){
-    
-    if(!("q50"%in%colnames(qrdata))){stop("q50 required for exponential tails.")}
-    
-    thickness <- rep(NA,tails$nBins)
-    targetquants <- stats::quantile(tails$targetvar,probs = seq(0, 1, 1/tails$nBins),na.rm=T)
-    for(i in 1:tails$nBins){
-      thickness[i] <- mean(tails$targetvar[which(qrdata$q50>=targetquants[i] & qrdata$q50<targetquants[i+1])],na.rm = T)
-    }
-    tails$thickparamFunc <- stepfun(seq(0,1,length.out = tails$nBins+1),y=c(0,thickness,1))
-    
-  }
-  
+
   if(tails$method=="dyn_exponential"){
-    print(paste0(tails$method," method valid for [0,1] target variable scale at the moment..."))
+    warning("tails$method==\"dyn_exponential\" only valid for target variable in [0,1].")
   }
   
-  
-  ## Get tail parameters if specified for each row of qrdata
+  ## Get names of parameters specified for each row of qrdata
   varying_params <- names(which(lapply(tails,length)==nrow(qrdata)))
   if (inverse){
     
@@ -63,8 +49,8 @@ PIT.MultiQR <- function(qrdata,obs,tails,inverse=FALSE,...){
         
         temp_tail <- tails
         if(length(varying_params)>0){
-          for(j in 1:length(varying_params)){
-            temp_tail[[varying_params[j]]] <- tails[[varying_params[j]]][i]
+          for(j in varying_params){
+            temp_tail[[j]] <- tails[[j]][i]
           }
         }
         
@@ -79,8 +65,8 @@ PIT.MultiQR <- function(qrdata,obs,tails,inverse=FALSE,...){
         
         temp_tail <- tails
         if(length(varying_params)>0){
-          for(j in 1:length(varying_params)){
-            temp_tail[[varying_params[j]]] <- tails[[varying_params[j]]][i]
+          for(j in varying_params){
+            temp_tail[[j]] <- tails[[j]][i]
           }
         }
         
@@ -175,9 +161,11 @@ PIT.PPD <- function(ppd,data,inverse=FALSE,inv_probs=NULL){
 #' @author Ciaran Gilbert, \email{ciaran.gilbert@@strath.ac.uk}
 #' @param models A Para_gamboostLSS object.
 #' @param data Input data corresponding to \code{qrdata}.
-#' @param dist_fun cumulative distribution function corresponging to families specified in gamboostLSS model (see example).
+#' @param dist_fun cumulative distribution function corresponging to families
+#' specified in gamboostLSS model (see example).
 #' @param response_name name of response variable in \code{data} object.
-#' @return The probability integral transform of \code{data} through the predictive distribution defined by a list of gamboostLSS objects.
+#' @return The probability integral transform of \code{data} through the predictive
+#' distribution defined by a list of gamboostLSS objects.
 #' @export
 PIT.gamboostLSS <- function(models,data,dist_fun,response_name,...){
   

--- a/R/contCDF.R
+++ b/R/contCDF.R
@@ -23,7 +23,7 @@
 #' Several options are available for specifying distribution tails beyond
 #' the final upper and lower quantiles:
 #' 
-#' Linear extrapolation: \code{tails=list(method="extrapolate",L,U)} value set to \code{L} and \code {U}
+#' Linear extrapolation: \code{tails=list(method="extrapolate",L,U)} value set to \code{L} and \code{U}
 #' for probability levels 0 and 1, respectively. If \code{method="extrapolate_dtail1"} then
 #' tails are exrapolated to the 50th quantile plus (minus) \code{U} (\code{L}).
 #' 
@@ -37,14 +37,17 @@
 #' thickness can be defined data-driven by specifying: number of bins \code{nbins}, a MQR
 #' object \code{preds}, and the target variable, \code{targetvar}.
 #' 
-#' Dynamic exponential tails: \code{tails=list(method="dyn_exponential",...)} ...
+#' Dynamic exponential tails: \code{tails=list(method="dyn_exponential",ntailpoints=5)}, where the tail shape
+#' is conditional on the values for the upper and lower quantile of \code{qrdata}. This method 
+#' currently only supports an input variable scale of \code{[0,1]}. The tail shape moves from linear interpolation
+#' when the upper/lower quantile is near the boundary for each respective tail, to a conditional exponential shape.
 #' 
 #' Generalised Pareto Distribution: \code{tails="gpd", scale_r,shape_r,
 #' scale_l,shape_l,tail_qs=seq(0.1,2,by=0.1)} with left (_l) and right (_r) scale and shape parameters.
 #' Quantiles are calculated at points defined by the upper (lower) quantile plus (minus)
 #' \code{tail_qs}.
 #' 
-#' @return A cumulative densift function of the type produced by \code{splinefun} and
+#' @return A cumulative density function of the type produced by \code{splinefun} and
 #' \code{approxfun}.
 #' @export
 contCDF <- function(quantiles,kfold=NULL,inverse=F,

--- a/R/contCDF.R
+++ b/R/contCDF.R
@@ -142,7 +142,8 @@ contCDF <- function(quantiles,kfold=NULL,inverse=F,
     
     if(is.null(tails$ntailpoints)){tails$ntailpoints <- 5}
     
-    # function only tested for inputs between zero and 1 at the moment, outwith that need to modify to capture minimum bound of tail
+    # function only tested for inputs between zero and 1 at the moment,
+    # outwith that need to modify to capture minimum bound of tail
     # watch dividing by 0....
     paraf <- function(rho,x,minq){
       if(rho<minq){rho <- minq}

--- a/R/contCDF.R
+++ b/R/contCDF.R
@@ -8,26 +8,46 @@
 #' @author Jethro Browell, \email{jethro.browell@@strath.ac.uk}; Ciaran Gilbert, \email{ciaran.gilbert@@strath.ac.uk}
 #' @param quantiles A single-row \code{MultiQR} object.
 #' @param kfolds Fold/test label corresponding to \code{quantiles}.
-#' @param method Method of interpolation. If \code{method="linear"} linear
-#' interpolation is used between quantiles. For spline interpolation,
-#' \code{method=list(name=spline,splinemethod)}, where spline method is
-#' passed to \code{splinefun}.
-#' @param tails Method for tails, this must be defined as a
-#' list with other control parameters. Default is linear interpolation
-#' of tails when \code{method="interpolate"} with boundaries at
-#' \code{L=0} and \code{U=1}. Exponential tails can be specified
-#' through \code{method="exponential"}, the user will either supply
-#' user defined thickness parameters for the tail via \code{thicknessPL}
-#' and \code{thicknessPR}, otherwise a symetrical tail thickness can be
-#' defined data-driven by specifying: number of bins \code{nbins}, a MQR
-#' object \code{preds}, and the target variable, \code{targetvar}. The number
-#' of interpolation points for the exponential can be defined via \code{ntailpoints}. 
+#' @param method Method of interpolation. See details.
+#' @param tails Definition of tails. See details.
+#' @details Interpolation between quantiles may be linear of via smooth splines:
+#' 
+#' Linear interpolation: \code{method="linear"} linear interpolation
+#' between quantiles.
+#' 
+#' Spline interpolation: \code{method=list(name=spline,splinemethod=monoH.FC)}, where spline method is
+#' passed to \code{splinefun}. \code{splinefun=monoH.FC} is recommended to gaurantee monotoincally
+#' increasing function.
+#' 
+#' 
+#' Several options are available for specifying distribution tails beyond
+#' the final upper and lower quantiles:
+#' 
+#' Linear extrapolation: \code{tails=list(method="extrapolate",L,U)} value set to \code{L} and \code {U}
+#' for probability levels 0 and 1, respectively. If \code{method="extrapolate_dtail1"} then
+#' tails are exrapolated to the 50th quantile plus (minus) \code{U} (\code{L}).
+#' 
+#' Exponential tails: \code{tails=list(method="exponential",thicknessPL,thicknessPR,ntailpoints=5)}
+#' the user will either supply user defined thickness parameters for the tail
+#' via \code{thicknessPL} and \code{thicknessPR}. The number
+#' of tail quantiles to be estimated is set by \code{ntailpoints}.
+#' Alternatively (not recommmended) a symetrical tail
+#' thickness can be defined data-driven by specifying: number of bins \code{nbins}, a MQR
+#' object \code{preds}, and the target variable, \code{targetvar}.
+#' 
+#' Dynamic exponential tails: \code{tails=list(method="dyn_exponential",...)} ...
+#' 
+#' Generalised Pareto Distribution: \code{tails="gpd", scale_r,shape_r,
+#' scale_l,shape_l,tail_qs=seq(0.1,2,by=0.1)} with left (_l) and right (_r) scale and shape parameters.
+#' Quantiles are calculated at points defined by the upper (lower) quantile plus (minus)
+#' \code{tail_qs}.
+#' 
 #' @return A cumulative densift function of the type produced by \code{splinefun} and
 #' \code{approxfun}.
 #' @export
 contCDF <- function(quantiles,kfold=NULL,inverse=F,
                     method=list(name="spline",splinemethod="monoH.FC"),
-                    tails=list(method="interpolate",L=0,U=1)){
+                    tails=list(method="extrapolate",L=0,U=1)){
   ### TESTING
   # quantiles = test1$pred_mqr[500,]
   # inverse=F
@@ -47,12 +67,12 @@ contCDF <- function(quantiles,kfold=NULL,inverse=F,
   quantiles <- as.numeric(quantiles)
   
   ### Tails
-  if(tails$method=="interpolate"){
+  if(tails$method=="interpolate" | tails$method=="extrapolate"){
     LnomP <- 0
     Lquants <- tails$L
     RnomP <- 1
     Rquants <- tails$U
-  }else if(tails$method=="interpolate_dtail1"){
+  }else if(tails$method=="interpolate_dtail1" | tails$method=="extrapolate_dtail1"){
     LnomP <- 0
     Lquants <- quantiles[which(Probs==0.5)] + tails$L
     RnomP <- 1
@@ -117,7 +137,53 @@ contCDF <- function(quantiles,kfold=NULL,inverse=F,
       
       # plot(x=c(Lquants,quantiles,Rquants),y=c(LnomP,Probs,RnomP))
       
-    }} else{stop("Tail specification not recognised.")}
+    }
+  }else if(tails$method=="dyn_exponential"){
+    
+    if(is.null(tails$ntailpoints)){tails$ntailpoints <- 5}
+    
+    # function only tested for inputs between zero and 1 at the moment, outwith that need to modify to capture minimum bound of tail
+    # watch dividing by 0....
+    paraf <- function(rho,x,minq){
+      if(rho<minq){rho <- minq}
+      x*rho*exp((1/x)^(1/(1-rho))*log(minq/rho))
+    }
+    
+    
+    # samplebetween 0-1 to get tail shape
+    Lquants <- seq(0,1,length.out = tails$ntailpoints)
+    # find nominal probabilities
+    LnomP <- paraf(min(quantiles),Lquants,min(Probs))
+    # remove max value from tail q[(Pr = min(probs))] and normalize shape between available quantile space
+    Lquants <- Lquants[1:(length(Lquants)-1)]*min(quantiles)
+    # remove max probability from tail (Pr = min(Probs))
+    LnomP<-LnomP[1:(length(LnomP)-1)]
+    
+    # same for R tail
+    Rquants <- seq(0,1,length.out = tails$ntailpoints)
+    RnomP <- rev(1-paraf(1-max(quantiles),Rquants,minq = 1-max(Probs)))
+    Rquants <- rev(((1-Rquants[2:length(Rquants)])*(1-max(quantiles)))+max(quantiles))
+    RnomP<-RnomP[2:length(RnomP)]
+    
+  } else if(tails$method=="gpd"){
+    
+    Rquants <- tails$tail_qs+rev(quantiles)[1]
+    RnomP <- pgpd(q=Rquants,location=rev(quantiles)[1],shape = tails$shape_r,scale=tails$scale_r)
+    RnomP[length(RnomP)] <- 1
+    RnomP <- RnomP*(1-rev(Probs)[1])+rev(Probs)[1]
+    # plot(Rquants,RnomP)
+    
+    Lquants <- tails$tail_qs
+    LnomP <- rev(1-pgpd(q=Lquants,location=0,shape = tails$shape_l,scale=tails$scale_l))
+    LnomP[1] <- 0
+    LnomP <- LnomP*Probs[1]
+    Lquants <- Lquants-max(Lquants)+quantiles[1]
+    # plot(Lquants,LnomP)
+    
+    # plot(c(Lquants,quantiles,Rquants),c(LnomP,Probs,RnomP))
+    
+    
+  }else{stop("Tail specification not recognised.")}
   
   
   
@@ -148,3 +214,12 @@ contCDF <- function(quantiles,kfold=NULL,inverse=F,
   }else{stop("Interpolation method not recognised.")}
 }
 
+
+
+pgpd <- function(q,location=0,scale,shape){
+  if(shape!=0){
+    1-(1+shape*(q-location)/scale)^(-1/shape)
+  }else{
+    1-exp(-(q-location)/scale)
+  }
+}

--- a/R/contCDF.R
+++ b/R/contCDF.R
@@ -31,7 +31,9 @@
 #' the user will either supply user defined thickness parameters for the tail
 #' via \code{thicknessPL} and \code{thicknessPR}. The number
 #' of tail quantiles to be estimated is set by \code{ntailpoints}.
-#' Alternatively (not recommmended) a symetrical tail
+#' Alternatively \code{tails=list(method="exponential",thickparamFunc)} where \code{thickparamFunc}
+#' is a function that takes the q50 as an input and returns the thickness parameter.
+#' Alternatively (not recommmended) \code{tails=list(method="exponential",preds,nbins,targetvar)} a symetrical tail
 #' thickness can be defined data-driven by specifying: number of bins \code{nbins}, a MQR
 #' object \code{preds}, and the target variable, \code{targetvar}.
 #' 
@@ -48,6 +50,7 @@
 contCDF <- function(quantiles,kfold=NULL,inverse=F,
                     method=list(name="spline",splinemethod="monoH.FC"),
                     tails=list(method="extrapolate",L=0,U=1)){
+  
   ### TESTING
   # quantiles = test1$pred_mqr[500,]
   # inverse=F

--- a/R/contCDF.R
+++ b/R/contCDF.R
@@ -167,6 +167,15 @@ contCDF <- function(quantiles,kfold=NULL,inverse=F,
     
   } else if(tails$method=="gpd"){
     
+    ## GPD Function
+    pgpd <- function(q,location=0,scale,shape){
+      if(shape!=0){
+        1-(1+shape*(q-location)/scale)^(-1/shape)
+      }else{
+        1-exp(-(q-location)/scale)
+      }
+    }
+    
     Rquants <- tails$tail_qs+rev(quantiles)[1]
     RnomP <- pgpd(q=Rquants,location=rev(quantiles)[1],shape = tails$shape_r,scale=tails$scale_r)
     RnomP[length(RnomP)] <- 1
@@ -216,10 +225,3 @@ contCDF <- function(quantiles,kfold=NULL,inverse=F,
 
 
 
-pgpd <- function(q,location=0,scale,shape){
-  if(shape!=0){
-    1-(1+shape*(q-location)/scale)^(-1/shape)
-  }else{
-    1-exp(-(q-location)/scale)
-  }
-}

--- a/man/PIT.MultiQR.Rd
+++ b/man/PIT.MultiQR.Rd
@@ -12,6 +12,7 @@
 \item{obs}{A vector of observations corresponding to the rows of \code{qrdata}.}
 
 \item{tails}{A list of arguments passed to \code{condCDF} defining the tails of the CDFs.
+See \code{?contCDF} for details.
 Tail parameters my have length 1 or length \code{nrow(qrdata)} if each row of qrdata
 has a corresponding parameter value.}
 

--- a/man/PIT.MultiQR.Rd
+++ b/man/PIT.MultiQR.Rd
@@ -11,7 +11,9 @@
 
 \item{obs}{A vector of observations corresponding to the rows of \code{qrdata}.}
 
-\item{tails}{A list of arguments passed to \code{condCDF} defining the tails of the CDFs.}
+\item{tails}{A list of arguments passed to \code{condCDF} defining the tails of the CDFs.
+Tail parameters my have length 1 or length \code{nrow(qrdata)} if each row of qrdata
+has a corresponding parameter value.}
 
 \item{inverse}{A \code{boolean}. If true, the inverse transformation is appiled, i.e. uniform variable
 to random variable from original distribution.}

--- a/man/PIT.gamboostLSS.Rd
+++ b/man/PIT.gamboostLSS.Rd
@@ -11,12 +11,14 @@
 
 \item{data}{Input data corresponding to \code{qrdata}.}
 
-\item{dist_fun}{cumulative distribution function corresponging to families specified in gamboostLSS model (see example).}
+\item{dist_fun}{cumulative distribution function corresponging to families
+specified in gamboostLSS model (see example).}
 
 \item{response_name}{name of response variable in \code{data} object.}
 }
 \value{
-The probability integral transform of \code{data} through the predictive distribution defined by a list of gamboostLSS objects.
+The probability integral transform of \code{data} through the predictive
+distribution defined by a list of gamboostLSS objects.
 }
 \description{
 This function calculates the probability integral transformation

--- a/man/contCDF.Rd
+++ b/man/contCDF.Rd
@@ -22,7 +22,7 @@ contCDF(
 \item{kfolds}{Fold/test label corresponding to \code{quantiles}.}
 }
 \value{
-A cumulative densift function of the type produced by \code{splinefun} and
+A cumulative density function of the type produced by \code{splinefun} and
 \code{approxfun}.
 }
 \description{
@@ -45,7 +45,7 @@ increasing function.
 Several options are available for specifying distribution tails beyond
 the final upper and lower quantiles:
 
-Linear extrapolation: \code{tails=list(method="extrapolate",L,U)} value set to \code{L} and \code {U}
+Linear extrapolation: \code{tails=list(method="extrapolate",L,U)} value set to \code{L} and \code{U}
 for probability levels 0 and 1, respectively. If \code{method="extrapolate_dtail1"} then
 tails are exrapolated to the 50th quantile plus (minus) \code{U} (\code{L}).
 
@@ -59,7 +59,10 @@ Alternatively (not recommmended) \code{tails=list(method="exponential",preds,nbi
 thickness can be defined data-driven by specifying: number of bins \code{nbins}, a MQR
 object \code{preds}, and the target variable, \code{targetvar}.
 
-Dynamic exponential tails: \code{tails=list(method="dyn_exponential",...)} ...
+Dynamic exponential tails: \code{tails=list(method="dyn_exponential",ntailpoints=5)}, where the tail shape
+is conditional on the values for the upper and lower quantile of \code{qrdata}. This method 
+currently only supports an input variable scale of \code{[0,1]}. The tail shape moves from linear interpolation
+when the upper/lower quantile is near the boundary for each respective tail, to a conditional exponential shape.
 
 Generalised Pareto Distribution: \code{tails="gpd", scale_r,shape_r,
 scale_l,shape_l,tail_qs=seq(0.1,2,by=0.1)} with left (_l) and right (_r) scale and shape parameters.

--- a/man/contCDF.Rd
+++ b/man/contCDF.Rd
@@ -52,19 +52,16 @@ tails are exrapolated to the 50th quantile plus (minus) \code{U} (\code{L}).
 Exponential tails: \code{tails=list(method="exponential",thicknessPL,thicknessPR,ntailpoints=5)}
 the user will either supply user defined thickness parameters for the tail
 via \code{thicknessPL} and \code{thicknessPR}. The number
-of tail quantiles to be estimated is set by \code{ntailpoints}.
+of tail quantiles to be estimated is set by \code{ntailpoints}, which defaults to 5.
 Alternatively \code{tails=list(method="exponential",thickparamFunc)} where \code{thickparamFunc}
 is a function that takes the q50 as an input and returns the thickness parameter.
-Alternatively (not recommmended) \code{tails=list(method="exponential",preds,nbins,targetvar)} a symetrical tail
-thickness can be defined data-driven by specifying: number of bins \code{nbins}, a MQR
-object \code{preds}, and the target variable, \code{targetvar}.
 
 Dynamic exponential tails: \code{tails=list(method="dyn_exponential",ntailpoints=5)}, where the tail shape
 is conditional on the values for the upper and lower quantile of \code{qrdata}. This method 
 currently only supports an input variable scale of \code{[0,1]}. The tail shape moves from linear interpolation
 when the upper/lower quantile is near the boundary for each respective tail, to a conditional exponential shape.
 
-Generalised Pareto Distribution: \code{tails="gpd", scale_r,shape_r,
+Generalised Pareto Distribution Tails: \code{tails="gpd", scale_r,shape_r,
 scale_l,shape_l,tail_qs=seq(0.1,2,by=0.1)} with left (_l) and right (_r) scale and shape parameters.
 Quantiles are calculated at points defined by the upper (lower) quantile plus (minus)
 \code{tail_qs}.

--- a/man/contCDF.Rd
+++ b/man/contCDF.Rd
@@ -9,27 +9,15 @@ contCDF(
   kfold = NULL,
   inverse = F,
   method = list(name = "spline", splinemethod = "monoH.FC"),
-  tails = list(method = "interpolate", L = 0, U = 1)
+  tails = list(method = "extrapolate", L = 0, U = 1)
 )
 }
 \arguments{
 \item{quantiles}{A single-row \code{MultiQR} object.}
 
-\item{method}{Method of interpolation. If \code{method="linear"} linear
-interpolation is used between quantiles. For spline interpolation,
-\code{method=list(name=spline,splinemethod)}, where spline method is
-passed to \code{splinefun}.}
+\item{method}{Method of interpolation. See details.}
 
-\item{tails}{Method for tails, this must be defined as a
-list with other control parameters. Default is linear interpolation
-of tails when \code{method="interpolate"} with boundaries at
-\code{L=0} and \code{U=1}. Exponential tails can be specified
-through \code{method="exponential"}, the user will either supply
-user defined thickness parameters for the tail via \code{thicknessPL}
-and \code{thicknessPR}, otherwise a symetrical tail thickness can be
-defined data-driven by specifying: number of bins \code{nbins}, a MQR
-object \code{preds}, and the target variable, \code{targetvar}. The number
-of interpolation points for the exponential can be defined via \code{ntailpoints}.}
+\item{tails}{Definition of tails. See details.}
 
 \item{kfolds}{Fold/test label corresponding to \code{quantiles}.}
 }
@@ -42,6 +30,41 @@ This function generats a smooth, continuous CDF a given row of a \code{MultiQR}
 object. Interpolation if performed between quantiles and a range of tail models
 are available for extrapolating beyond beyond the last estimated upper and lower
 quantile.
+}
+\details{
+Interpolation between quantiles may be linear of via smooth splines:
+
+Linear interpolation: \code{method="linear"} linear interpolation
+between quantiles.
+
+Spline interpolation: \code{method=list(name=spline,splinemethod=monoH.FC)}, where spline method is
+passed to \code{splinefun}. \code{splinefun=monoH.FC} is recommended to gaurantee monotoincally
+increasing function.
+
+
+Several options are available for specifying distribution tails beyond
+the final upper and lower quantiles:
+
+Linear extrapolation: \code{tails=list(method="extrapolate",L,U)} value set to \code{L} and \code {U}
+for probability levels 0 and 1, respectively. If \code{method="extrapolate_dtail1"} then
+tails are exrapolated to the 50th quantile plus (minus) \code{U} (\code{L}).
+
+Exponential tails: \code{tails=list(method="exponential",thicknessPL,thicknessPR,ntailpoints=5)}
+the user will either supply user defined thickness parameters for the tail
+via \code{thicknessPL} and \code{thicknessPR}. The number
+of tail quantiles to be estimated is set by \code{ntailpoints}.
+Alternatively \code{tails=list(method="exponential",thickparamFunc)} where \code{thickparamFunc}
+is a function that takes the q50 as an input and returns the thickness parameter.
+Alternatively (not recommmended) \code{tails=list(method="exponential",preds,nbins,targetvar)} a symetrical tail
+thickness can be defined data-driven by specifying: number of bins \code{nbins}, a MQR
+object \code{preds}, and the target variable, \code{targetvar}.
+
+Dynamic exponential tails: \code{tails=list(method="dyn_exponential",...)} ...
+
+Generalised Pareto Distribution: \code{tails="gpd", scale_r,shape_r,
+scale_l,shape_l,tail_qs=seq(0.1,2,by=0.1)} with left (_l) and right (_r) scale and shape parameters.
+Quantiles are calculated at points defined by the upper (lower) quantile plus (minus)
+\code{tail_qs}.
 }
 \author{
 Jethro Browell, \email{jethro.browell@strath.ac.uk}; Ciaran Gilbert, \email{ciaran.gilbert@strath.ac.uk}


### PR DESCRIPTION
You're right - I accidentally reverted to an older version of the function when dealing with a conflict in the documentation.

I think I've put the correct version back now and also improved the documentation.

@ciaran-g please can you add a sentence or two explaining how the dyn_exp tails work?

I'd also like to remove the entire block that estimates the thickness parameter based on binning p50 etc from both contCDF and PIT. Do you have any objection? It was there to test and has hung around too long! I've made a mod to PIT to allow for vectors of parameters in the tail=list(...) corresponding to each row of the MultiQR... See PIT.   