### PR TITLE
More flexible eval subests

### DIFF
--- a/Example.R
+++ b/Example.R
@@ -64,7 +64,8 @@ lines(test1$data$TARGETVAR[which(test1$data$ISSUEdtm==i_ts)],lwd=3)
 
 reliability(qrdata = test1$gbm_mqr,
             realisations = test1$data$TARGETVAR,
-            kfolds = test1$data$kfold)
+            subsets = test1$data$WS100,
+            breaks = c(4,10),bootstrap = 100)
 
 pinball(qrdata = test1$gbm_mqr,
          realisations = test1$data$TARGETVAR,

--- a/R/pinball.R
+++ b/R/pinball.R
@@ -1,8 +1,9 @@
 #' Pinball Score for \code{MultiQR} Objects
 #' 
-#' @description This function calculates the pinball score for each quantile in a \code{MultiQR}
-#' object. Optionally, results are produced by cross-validation fold or covariate,
-#' 95\% confidence intervals are estimated via bootstrap, and results are plotted.
+#' @description This function calculates the pinball score for each quantile in a
+#' \code{MultiQR} object. Optionally, results are produced by cross-validation fold
+#' or covariate, 95\% confidence intervals are estimated via bootstrap, and results
+#' are plotted.
 #' 
 #' @author Jethro Browell, \email{jethro.browell@@strath.ac.uk}
 #' @param qrdata \code{MultiQR} object.
@@ -12,23 +13,20 @@
 #' Cannot be used with \code{subsets}.
 #' @param subsets Optional vector of covariates to bin data by.
 #' Breaks between bins are the empirical quantiles of
-#' \code{subsets} by default or all unique factors or charater strings.
+#' \code{subsets} by default or all unique factors or charater strings. Custom
+#' breaks may be specifed, see \code{breaks}.
 #' Cannot be used with \code{kfolds}.
 #' @param breaks Either the number of quantiles to use to bin \code{subsets} by (resulting
 #' in \code{breaks+1} bins, defaults to \code{breaks=4}), or, if \code{length(breaks) > 1}, a vector of spcific break
-#' points. \code{subsets} must be provided.
-#' @param bootstrap Calculate this number of boostrap samples
-#' to estimate 95\% confdence interval.
-#' @param plot.it \code{boolean}. Make a plot?
-#' @param subsets Covariate to subset evaluation metric by corresponding to rows of \code{qrdata}.
-#' @param breaks number of subsets to form.
+#' points. Only used if \code{subsets} provided.
 #' @param bootstrap Number of boostrap samples used to generate 95\% confidence intervals.
+#' @param plot.it \code{boolean}. Make a plot?
 #' @param ... Additional arguments passed to \code{plot()}.
 #' @details Missing values in \code{realisations} are handled by \code{na.rm=T} when
 #' calculating average exceedence of a given quantile.
 #' @return Quantile Score data and, if \code{plot.it=T}, a plot.
 #' @export
-pinball <- function(qrdata,realisations,kfolds=NULL,plot.it=T,subsets=NULL,breaks=4,bootstrap=NULL,...){
+pinball <- function(qrdata,realisations,kfolds=NULL,subsets=NULL,breaks=4,bootstrap=NULL,plot.it=T,...){
   
   if(nrow(qrdata)!=length(realisations)){stop("nrow(qrdata)!=length(realisations)")}
   if(!is.null(kfolds)){

--- a/R/pinball.R
+++ b/R/pinball.R
@@ -37,7 +37,7 @@ pinball <- function(qrdata,realisations,kfolds=NULL,plot.it=T,subsets=NULL,break
     if(length(subsets)!=length(realisations)){stop("!is.null(subsets) & nrow(subsets)!=length(realisations)")}
   }
   if(!is.null(kfolds) & !is.null(subsets)){stop("Only one of subsets and kfolds can !=NULL.")}
-  if(breaks<1){stop("breaks must be a positive integer.")}
+  if(length(breaks) ==1 & breaks[1]<1){stop("breaks must be a positive integer.")}
   
   qs <- as.numeric(gsub(colnames(qrdata),pattern = "q",replacement = ""))/100
   
@@ -255,17 +255,17 @@ pinball <- function(qrdata,realisations,kfolds=NULL,plot.it=T,subsets=NULL,break
                pch=c(rep(16,length(lvls))),bty = "n",cex=.7,ncol = 2)
         
       } else{
-        if(breaks==1){
+        if(length(breaks)==1 & breaks[1]==1){
           legend("topleft",c(paste0("<=",break_qs[2]),paste0(">",break_qs[2])),
                  lty=c(rep(1,breaks+1)),
                  col=c(rainbow(breaks+1)),
                  pch=c(rep(16,breaks+1)),bty = "n")
         }else{
-          legend("topleft",c(paste0(c("<=",paste0(signif(break_qs[2:breaks],digits=2)," to "),">"),
-                                    signif(break_qs[c(2:(breaks+1),breaks+1)],digits=2))),
-                 lty=c(rep(1,breaks+1)),
-                 col=c(rainbow(breaks+1)),
-                 pch=c(rep(16,breaks+1)),bty = "n")
+          legend("topleft",c(paste0(c("<=",paste0(signif(break_qs[2:(length(break_qs)-2)],digits=2)," to "),">"),
+                                    signif(break_qs[c(2:((length(break_qs)-2)+1),(length(break_qs)-2)+1)],digits=2))),
+                 lty=c(rep(1,length(break_qs)-1)),
+                 col=c(rainbow(length(break_qs)-1)),
+                 pch=c(rep(16,length(break_qs)-1)),bty = "n")
         }
       }
       

--- a/R/pinball.R
+++ b/R/pinball.R
@@ -43,7 +43,7 @@ pinball <- function(qrdata,realisations,kfolds=NULL,plot.it=T,subsets=NULL,break
   if(!is.null(kfolds)){
     total <- "All_cv"} else{
       total <- "All"  
-  }
+    }
   
   PBL <- data.frame(Quantile=qs,
                     Loss=as.numeric(rep(NA,length(qs))),
@@ -53,42 +53,42 @@ pinball <- function(qrdata,realisations,kfolds=NULL,plot.it=T,subsets=NULL,break
                     lower=NA)
   for(q in qs){
     if(total == "All_cv"){
-    PBL$Loss[which(qs==q)] <- mean(((realisations-qrdata[[paste0("q",100*q)]])*q*(realisations>=qrdata[[paste0("q",100*q)]])+
-                                     (realisations-qrdata[[paste0("q",100*q)]])*(q-1)*(realisations<qrdata[[paste0("q",100*q)]]))[kfolds!="Test"],
-                                   na.rm = T)
-    
-    if(!is.null(bootstrap)){
-      bs_data <- rep(NA,bootstrap)
-      for(i in 1:bootstrap){
-        data_length <- length(qrdata[[paste0("q",100*q)]][kfolds!="Test"])
-        i_samp <- sample(1:data_length,size = data_length,replace = T)
-        bs_data[i] <- mean(((realisations-qrdata[[paste0("q",100*q)]])*q*(realisations>=qrdata[[paste0("q",100*q)]])+
-                              (realisations-qrdata[[paste0("q",100*q)]])*(q-1)*(realisations<qrdata[[paste0("q",100*q)]]))[kfolds!="Test"][i_samp],
-                           na.rm = T)        
+      PBL$Loss[which(qs==q)] <- mean(((realisations-qrdata[[paste0("q",100*q)]])*q*(realisations>=qrdata[[paste0("q",100*q)]])+
+                                        (realisations-qrdata[[paste0("q",100*q)]])*(q-1)*(realisations<qrdata[[paste0("q",100*q)]]))[kfolds!="Test"],
+                                     na.rm = T)
+      
+      if(!is.null(bootstrap)){
+        bs_data <- rep(NA,bootstrap)
+        for(i in 1:bootstrap){
+          data_length <- length(qrdata[[paste0("q",100*q)]][kfolds!="Test"])
+          i_samp <- sample(1:data_length,size = data_length,replace = T)
+          bs_data[i] <- mean(((realisations-qrdata[[paste0("q",100*q)]])*q*(realisations>=qrdata[[paste0("q",100*q)]])+
+                                (realisations-qrdata[[paste0("q",100*q)]])*(q-1)*(realisations<qrdata[[paste0("q",100*q)]]))[kfolds!="Test"][i_samp],
+                             na.rm = T)        
+        }
+        PBL$upper[which(qs==q)] <- quantile(bs_data,probs = 0.975)
+        PBL$lower[which(qs==q)] <- quantile(bs_data,probs = 0.025)
       }
-      PBL$upper[which(qs==q)] <- quantile(bs_data,probs = 0.975)
-      PBL$lower[which(qs==q)] <- quantile(bs_data,probs = 0.025)
-    }
-    
-    
+      
+      
     } else{
-    PBL$Loss[which(qs==q)] <- mean((realisations-qrdata[[paste0("q",100*q)]])*q*(realisations>=qrdata[[paste0("q",100*q)]])+
-                                      (realisations-qrdata[[paste0("q",100*q)]])*(q-1)*(realisations<qrdata[[paste0("q",100*q)]]),na.rm = T)
-    
-    
-    if(!is.null(bootstrap)){
-      bs_data <- rep(NA,bootstrap)
-      for(i in 1:bootstrap){
-        data_length <- length(qrdata[[paste0("q",100*q)]])
-        i_samp <- sample(1:data_length,size = data_length,replace = T)
-        bs_data[i] <- mean(((realisations-qrdata[[paste0("q",100*q)]])*q*(realisations>=qrdata[[paste0("q",100*q)]])+
-                             (realisations-qrdata[[paste0("q",100*q)]])*(q-1)*(realisations<qrdata[[paste0("q",100*q)]]))[i_samp],na.rm = T)        
+      PBL$Loss[which(qs==q)] <- mean((realisations-qrdata[[paste0("q",100*q)]])*q*(realisations>=qrdata[[paste0("q",100*q)]])+
+                                       (realisations-qrdata[[paste0("q",100*q)]])*(q-1)*(realisations<qrdata[[paste0("q",100*q)]]),na.rm = T)
+      
+      
+      if(!is.null(bootstrap)){
+        bs_data <- rep(NA,bootstrap)
+        for(i in 1:bootstrap){
+          data_length <- length(qrdata[[paste0("q",100*q)]])
+          i_samp <- sample(1:data_length,size = data_length,replace = T)
+          bs_data[i] <- mean(((realisations-qrdata[[paste0("q",100*q)]])*q*(realisations>=qrdata[[paste0("q",100*q)]])+
+                                (realisations-qrdata[[paste0("q",100*q)]])*(q-1)*(realisations<qrdata[[paste0("q",100*q)]]))[i_samp],na.rm = T)        
+        }
+        PBL$upper[which(qs==q)] <- quantile(bs_data,probs = 0.975)
+        PBL$lower[which(qs==q)] <- quantile(bs_data,probs = 0.025)
       }
-      PBL$upper[which(qs==q)] <- quantile(bs_data,probs = 0.975)
-      PBL$lower[which(qs==q)] <- quantile(bs_data,probs = 0.025)
-    }
-    
-    
+      
+      
     }
   }
   
@@ -168,48 +168,51 @@ pinball <- function(qrdata,realisations,kfolds=NULL,plot.it=T,subsets=NULL,break
         
         PBL <- rbind(PBL,tempPBL)
       }
-  
+      
       
       
     } else {
       
-    break_qs <- quantile(subsets,probs = seq(from = 1/(breaks+1),by=1/(breaks+1),length.out=breaks),na.rm = T)
-    break_qs <- c(-Inf,break_qs,Inf)
-      
-
-    for(i in 2:length(break_qs)){
-      indexs <- which(subsets>break_qs[i-1] & subsets<=break_qs[i])  
-      
-      
-      tempPBL <- data.frame(Quantile=qs,
-                            Loss=as.numeric(rep(NA,length(qs))),
-                            kfold=NA,
-                            subset = i-1,
-                            upper=NA,
-                            lower=NA)
-      for(q in qs){
-        
-        tempPBL$Loss[which(qs==q)] <- mean(((realisations-qrdata[[paste0("q",100*q)]])*q*(realisations>=qrdata[[paste0("q",100*q)]])+
-                                              (realisations-qrdata[[paste0("q",100*q)]])*(q-1)*(realisations<qrdata[[paste0("q",100*q)]]))[indexs],
-             na.rm = T)
-        
-        if(!is.null(bootstrap)){
-          bs_data <- rep(NA,bootstrap)
-          for(j in 1:bootstrap){
-            data_length <- length(qrdata[[paste0("q",100*q)]][indexs])
-            i_samp <- sample(1:data_length,size = data_length,replace = T)
-            bs_data[j] <- mean(((realisations-qrdata[[paste0("q",100*q)]])*q*(realisations>=qrdata[[paste0("q",100*q)]])+
-                                  (realisations-qrdata[[paste0("q",100*q)]])*(q-1)*(realisations<qrdata[[paste0("q",100*q)]]))[indexs][i_samp],na.rm = T)
-          }
-          tempPBL$upper[which(qs==q)] <- quantile(bs_data,probs = 0.975)
-          tempPBL$lower[which(qs==q)] <- quantile(bs_data,probs = 0.025)
-        }
-        
+      if(length(breaks)==1){
+        break_qs <- quantile(subsets,probs = seq(from = 1/(breaks+1),by=1/(breaks+1),length.out=breaks),na.rm = T)
+        break_qs <- c(-Inf,break_qs,Inf)
+      }else{
+        break_qs <- c(-Inf,breaks,Inf)
       }
       
-      
-      PBL <- rbind(PBL,tempPBL)
-    }
+      for(i in 2:length(break_qs)){
+        indexs <- which(subsets>break_qs[i-1] & subsets<=break_qs[i])  
+        
+        
+        tempPBL <- data.frame(Quantile=qs,
+                              Loss=as.numeric(rep(NA,length(qs))),
+                              kfold=NA,
+                              subset = i-1,
+                              upper=NA,
+                              lower=NA)
+        for(q in qs){
+          
+          tempPBL$Loss[which(qs==q)] <- mean(((realisations-qrdata[[paste0("q",100*q)]])*q*(realisations>=qrdata[[paste0("q",100*q)]])+
+                                                (realisations-qrdata[[paste0("q",100*q)]])*(q-1)*(realisations<qrdata[[paste0("q",100*q)]]))[indexs],
+                                             na.rm = T)
+          
+          if(!is.null(bootstrap)){
+            bs_data <- rep(NA,bootstrap)
+            for(j in 1:bootstrap){
+              data_length <- length(qrdata[[paste0("q",100*q)]][indexs])
+              i_samp <- sample(1:data_length,size = data_length,replace = T)
+              bs_data[j] <- mean(((realisations-qrdata[[paste0("q",100*q)]])*q*(realisations>=qrdata[[paste0("q",100*q)]])+
+                                    (realisations-qrdata[[paste0("q",100*q)]])*(q-1)*(realisations<qrdata[[paste0("q",100*q)]]))[indexs][i_samp],na.rm = T)
+            }
+            tempPBL$upper[which(qs==q)] <- quantile(bs_data,probs = 0.975)
+            tempPBL$lower[which(qs==q)] <- quantile(bs_data,probs = 0.025)
+          }
+          
+        }
+        
+        
+        PBL <- rbind(PBL,tempPBL)
+      }
       
     }
     
@@ -251,77 +254,77 @@ pinball <- function(qrdata,realisations,kfolds=NULL,plot.it=T,subsets=NULL,break
                pch=c(rep(16,length(lvls))),bty = "n",cex=.7,ncol = 2)
         
       } else{
-      if(breaks==1){
-        legend("topleft",c(paste0("<=",break_qs[2]),paste0(">",break_qs[2])),
-               lty=c(rep(1,breaks+1)),
-               col=c(rainbow(breaks+1)),
-               pch=c(rep(16,breaks+1)),bty = "n")
-      }else{
-        legend("topleft",c(paste0(c("<=",paste0(signif(break_qs[2:breaks],digits=2)," to "),">"),
-                                          signif(break_qs[c(2:(breaks+1),breaks+1)],digits=2))),
-               lty=c(rep(1,breaks+1)),
-               col=c(rainbow(breaks+1)),
-               pch=c(rep(16,breaks+1)),bty = "n")
+        if(breaks==1){
+          legend("topleft",c(paste0("<=",break_qs[2]),paste0(">",break_qs[2])),
+                 lty=c(rep(1,breaks+1)),
+                 col=c(rainbow(breaks+1)),
+                 pch=c(rep(16,breaks+1)),bty = "n")
+        }else{
+          legend("topleft",c(paste0(c("<=",paste0(signif(break_qs[2:breaks],digits=2)," to "),">"),
+                                    signif(break_qs[c(2:(breaks+1),breaks+1)],digits=2))),
+                 lty=c(rep(1,breaks+1)),
+                 col=c(rainbow(breaks+1)),
+                 pch=c(rep(16,breaks+1)),bty = "n")
+        }
       }
-      }
-    
+      
       
     } else{
       
-    
-    
-    plot(PBL[which(PBL$kfold==total),1:2],type="b",pch=16,
-         xlim=c(0,1),
-         ylab="Pinball Loss",col="blue",...)
-    grid()
-    
-    if(!is.null(bootstrap)){
-      polygon(x = c(PBL$Quantile[which(PBL$kfold==total)],rev(PBL$Quantile[which(PBL$kfold==total)])),
-              y=c(PBL$upper[which(PBL$kfold==total)],rev(PBL$lower[which(PBL$kfold==total)])),
-              col = rgb(0,0,1,alpha = 0.3),border = NA)
       
-    }
-    
-    if(!is.null(kfolds)){
-      for(fold in unique(kfolds)){
-        if(fold!="Test"){
-          
-          lines(PBL[which(PBL$kfold==fold),1:2],type="b",pch=16,col="Grey50")
-          
-          if(!is.null(bootstrap)){
-            polygon(x = c(PBL$Quantile[which(PBL$kfold==fold)],rev(PBL$Quantile[which(PBL$kfold==fold)])),
-                    y=c(PBL$upper[which(PBL$kfold==fold)],rev(PBL$lower[which(PBL$kfold==fold)])),
-                    col = grey(.5,alpha = 0.3),border = NA)
+      
+      plot(PBL[which(PBL$kfold==total),1:2],type="b",pch=16,
+           xlim=c(0,1),
+           ylab="Pinball Loss",col="blue",...)
+      grid()
+      
+      if(!is.null(bootstrap)){
+        polygon(x = c(PBL$Quantile[which(PBL$kfold==total)],rev(PBL$Quantile[which(PBL$kfold==total)])),
+                y=c(PBL$upper[which(PBL$kfold==total)],rev(PBL$lower[which(PBL$kfold==total)])),
+                col = rgb(0,0,1,alpha = 0.3),border = NA)
+        
+      }
+      
+      if(!is.null(kfolds)){
+        for(fold in unique(kfolds)){
+          if(fold!="Test"){
             
-          }
-          
-        } else{
-          lines(PBL[which(PBL$kfold==fold),1:2],type="b",pch=16,col="red")
-          
-          
-          if(!is.null(bootstrap)){
-            polygon(x = c(PBL$Quantile[which(PBL$kfold==fold)],rev(PBL$Quantile[which(PBL$kfold==fold)])),
-                    y=c(PBL$upper[which(PBL$kfold==fold)],rev(PBL$lower[which(PBL$kfold==fold)])),
-                    col = rgb(1,0,0,alpha = 0.3),border = NA)
+            lines(PBL[which(PBL$kfold==fold),1:2],type="b",pch=16,col="Grey50")
+            
+            if(!is.null(bootstrap)){
+              polygon(x = c(PBL$Quantile[which(PBL$kfold==fold)],rev(PBL$Quantile[which(PBL$kfold==fold)])),
+                      y=c(PBL$upper[which(PBL$kfold==fold)],rev(PBL$lower[which(PBL$kfold==fold)])),
+                      col = grey(.5,alpha = 0.3),border = NA)
+              
+            }
+            
+          } else{
+            lines(PBL[which(PBL$kfold==fold),1:2],type="b",pch=16,col="red")
+            
+            
+            if(!is.null(bootstrap)){
+              polygon(x = c(PBL$Quantile[which(PBL$kfold==fold)],rev(PBL$Quantile[which(PBL$kfold==fold)])),
+                      y=c(PBL$upper[which(PBL$kfold==fold)],rev(PBL$lower[which(PBL$kfold==fold)])),
+                      col = rgb(1,0,0,alpha = 0.3),border = NA)
+              
+            }
             
           }
           
         }
-
+        lines(PBL[PBL$kfold==total,1:2],type="b",pch=16,col="blue")
       }
-      lines(PBL[PBL$kfold==total,1:2],type="b",pch=16,col="blue")
-    }
-    
-
-    
-    if(!is.null(kfolds) & !("Test"%in%kfolds)){
-      legend("topleft",c(total,"CV Folds"),lty=c(1,1),col=c("blue","Grey50"),pch=c(16,16),bty = "n")
-    }else if("Test"%in%kfolds){
-      lines(PBL[PBL$kfold=="Test",1:2],type="b",pch=16,col="red")
-      legend("topleft",c("Test",total,"CV Folds"),lty=c(1,1,1),col=c("red","blue","Grey50"),pch=c(16,16,16),bty = "n")
-    }
-  
-    
+      
+      
+      
+      if(!is.null(kfolds) & !("Test"%in%kfolds)){
+        legend("topleft",c(total,"CV Folds"),lty=c(1,1),col=c("blue","Grey50"),pch=c(16,16),bty = "n")
+      }else if("Test"%in%kfolds){
+        lines(PBL[PBL$kfold=="Test",1:2],type="b",pch=16,col="red")
+        legend("topleft",c("Test",total,"CV Folds"),lty=c(1,1,1),col=c("red","blue","Grey50"),pch=c(16,16,16),bty = "n")
+      }
+      
+      
     }
   }
   

--- a/R/pinball.R
+++ b/R/pinball.R
@@ -12,9 +12,10 @@
 #' Cannot be used with \code{subsets}.
 #' @param subsets Optional vector of covariates to bin data by.
 #' Breaks between bins are the empirical quantiles of
-#' \code{subsets}. Cannot be used with \code{kfolds}.
+#' \code{subsets} bu default or all unique factors or charater strings.
+#' Cannot be used with \code{kfolds}.
 #' @param breaks Number of quantiles to divide subsets by, results
-#' in \code{breaks+1} bins.
+#' in \code{breaks+1} bins, or is length > 1, a vector of break points.
 #' @param bootstrap Calculate this number of boostrap samples
 #' to estimate 95\% confdence interval.
 #' @param plot.it \code{boolean}. Make a plot?

--- a/R/pinball.R
+++ b/R/pinball.R
@@ -12,10 +12,11 @@
 #' Cannot be used with \code{subsets}.
 #' @param subsets Optional vector of covariates to bin data by.
 #' Breaks between bins are the empirical quantiles of
-#' \code{subsets} bu default or all unique factors or charater strings.
+#' \code{subsets} by default or all unique factors or charater strings.
 #' Cannot be used with \code{kfolds}.
-#' @param breaks Number of quantiles to divide subsets by, results
-#' in \code{breaks+1} bins, or is length > 1, a vector of break points.
+#' @param breaks Either the number of quantiles to use to bin \code{subsets} by (resulting
+#' in \code{breaks+1} bins, defaults to \code{breaks=4}), or, if \code{length(breaks) > 1}, a vector of spcific break
+#' points. \code{subsets} must be provided.
 #' @param bootstrap Calculate this number of boostrap samples
 #' to estimate 95\% confdence interval.
 #' @param plot.it \code{boolean}. Make a plot?
@@ -227,7 +228,7 @@ pinball <- function(qrdata,realisations,kfolds=NULL,plot.it=T,subsets=NULL,break
     
     if(!is.null(subsets)){
       
-      plot(PBL[which(PBL$subset==1),1:2],type="b",pch=16,
+      plot(PBL[,1:2],type="b",pch=16,
            xlim=c(0,1),
            ylab="Pinball Loss",col="white",...)
       grid()
@@ -272,12 +273,12 @@ pinball <- function(qrdata,realisations,kfolds=NULL,plot.it=T,subsets=NULL,break
       
     } else{
       
-      
-      
-      plot(PBL[which(PBL$kfold==total),1:2],type="b",pch=16,
+      plot(PBL[,1:2],type="b",pch=16,
            xlim=c(0,1),
-           ylab="Pinball Loss",col="blue",...)
+           ylab="Pinball Loss",col="white",...)
+      
       grid()
+      lines(PBL[which(PBL$kfold==total),1:2],type="b",pch=16)
       
       if(!is.null(bootstrap)){
         polygon(x = c(PBL$Quantile[which(PBL$kfold==total)],rev(PBL$Quantile[which(PBL$kfold==total)])),

--- a/R/reliability.R
+++ b/R/reliability.R
@@ -14,13 +14,14 @@
 #' to rows of \code{qrdata}. Cannot be used with \code{subsets}.
 #' @param subsets Optional vector of covariates to bin data by.
 #' Breaks between bins are the empirical quantiles of
-#' \code{subsets} by default or all unique factors or charater strings.
+#' \code{subsets} by default or all unique factors or charater strings. Custom
+#' breaks may be specifed, see \code{breaks}.
 #' Cannot be used with \code{kfolds}.
 #' @param breaks Either the number of quantiles to use to bin \code{subsets} by (resulting
 #' in \code{breaks+1} bins, defaults to \code{breaks=4}), or, if \code{length(breaks) > 1}, a vector of spcific break
+#' points. Only used if \code{subsets} provided.
 #' points. \code{subsets} must be provided.
-#' @param bootstrap Calculate this number of boostrap samples
-#' to estimate 95\% confdence interval
+#' @param bootstrap Number of boostrap samples used to generate 95\% confidence intervals.
 #' @param plot.it \code{boolean}. Make a plot?
 #' @param ... Additional arguments passed to \code{plot()}.
 #' @details Missing values in \code{realisations} are handled by \code{na.rm=T} when

--- a/R/reliability.R
+++ b/R/reliability.R
@@ -14,9 +14,10 @@
 #' to rows of \code{qrdata}. Cannot be used with \code{subsets}.
 #' @param subsets Optional vector of covariates to bin data by.
 #' Breaks between bins are the empirical quantiles of
-#' \code{subsets}. Cannot be used with \code{kfolds}.
+#' \code{subsets} bu default or all unique factors or charater strings.
+#' Cannot be used with \code{kfolds}.
 #' @param breaks Number of quantiles to divide subsets by, results
-#' in \code{breaks+1} bins.
+#' in \code{breaks+1} bins, or is length > 1, a vector of break points.
 #' @param bootstrap Calculate this number of boostrap samples
 #' to estimate 95\% confdence interval
 #' @param plot.it \code{boolean}. Make a plot?

--- a/R/reliability.R
+++ b/R/reliability.R
@@ -36,7 +36,7 @@ reliability <- function(qrdata,realisations,kfolds=NULL,subsets=NULL,breaks=4,bo
     if(length(subsets)!=length(realisations)){stop("!is.null(subsets) & nrow(subsets)!=length(realisations)")}
   }
   if(!is.null(kfolds) & !is.null(subsets)){stop("Only one of subsets and kfolds can !=NULL.")}
-  if(breaks<1){stop("breaks must be a positive integer.")}
+  if(length(breaks) ==1 & breaks[1]<1){stop("breaks must be a positive integer.")}
   
   qs <- as.numeric(gsub(colnames(qrdata),pattern = "q",replacement = ""))/100
   
@@ -150,10 +150,10 @@ reliability <- function(qrdata,realisations,kfolds=NULL,subsets=NULL,breaks=4,bo
           if(!is.null(bootstrap)){
             polygon(x = c(tempRel$Nominal,rev(tempRel$Nominal)),
                     y=c(tempRel$upper,rev(tempRel$lower)),
-                    col = rainbow(breaks+1,alpha = 0.3)[i-1],border = NA)
+                    col = rainbow(length(unique(subsets)),alpha = 0.3)[(which(unique(subsets)==i))],border = NA)
           }
           
-          lines(tempRel$Nominal,tempRel$Empirical,type="b",col=rainbow(breaks+1)[i-1],pch=16)
+          lines(tempRel$Nominal,tempRel$Empirical,type="b",col=rainbow(length(unique(subsets)))[(which(unique(subsets)==i))],pch=16)
         }
         
         Rel <- rbind(Rel,tempRel)
@@ -199,10 +199,10 @@ reliability <- function(qrdata,realisations,kfolds=NULL,subsets=NULL,breaks=4,bo
           if(!is.null(bootstrap)){
             polygon(x = c(tempRel$Nominal,rev(tempRel$Nominal)),
                     y=c(tempRel$upper,rev(tempRel$lower)),
-                    col = rainbow(breaks+1,alpha = 0.3)[i-1],border = NA)
+                    col = rainbow(length(break_qs)-1,alpha = 0.3)[i-1],border = NA)
           }
           
-          lines(tempRel$Nominal,tempRel$Empirical,type="b",col=rainbow(breaks+1)[i-1],pch=16)
+          lines(tempRel$Nominal,tempRel$Empirical,type="b",col=rainbow(length(break_qs)-1)[i-1],pch=16)
         }
         
         Rel <- rbind(Rel,tempRel)
@@ -213,18 +213,31 @@ reliability <- function(qrdata,realisations,kfolds=NULL,subsets=NULL,breaks=4,bo
   
   if(plot.it){
     grid()
+    
+    lvls <- na.omit(unique(Rel$subset))
+    
+    
     if(!is.null(subsets)){
-      if(breaks==1){
-        legend("topleft",c("Ideal",paste0("<=",break_qs[2]),paste0(">",break_qs[2])),
-               lty=c(2,rep(1,breaks+1)),
-               col=c(1,rainbow(breaks+1)),
-               pch=c(NA,rep(16,breaks+1)),bty = "n")
-      }else{
-        legend("topleft",c("Ideal",paste0(c("<=",paste0(signif(break_qs[2:breaks],digits=2)," to "),">"),
-                                          signif(break_qs[c(2:(breaks+1),breaks+1)],digits=2))),
-               lty=c(2,rep(1,breaks+1)),
-               col=c(1,rainbow(breaks+1)),
-               pch=c(NA,rep(16,breaks+1)),bty = "n")
+      if(is.factor(subsets) | is.character(subsets)){
+        
+        legend("topleft",lvls,
+               lty=c(rep(1,length(lvls))),
+               col=c(rainbow(length(lvls))),
+               pch=c(rep(16,length(lvls))),bty = "n",cex=.7,ncol = 2)
+        
+      } else{
+        if(length(breaks)==1 & breaks[1]==1){
+          legend("topleft",c(paste0("<=",break_qs[2]),paste0(">",break_qs[2])),
+                 lty=c(rep(1,breaks+1)),
+                 col=c(rainbow(breaks+1)),
+                 pch=c(rep(16,breaks+1)),bty = "n")
+        }else{
+          legend("topleft",c(paste0(c("<=",paste0(signif(break_qs[2:(length(break_qs)-2)],digits=2)," to "),">"),
+                                    signif(break_qs[c(2:((length(break_qs)-2)+1),(length(break_qs)-2)+1)],digits=2))),
+                 lty=c(rep(1,length(break_qs)-1)),
+                 col=c(rainbow(length(break_qs)-1)),
+                 pch=c(rep(16,length(break_qs)-1)),bty = "n")
+        }
       }
     }else{
       

--- a/R/reliability.R
+++ b/R/reliability.R
@@ -14,10 +14,11 @@
 #' to rows of \code{qrdata}. Cannot be used with \code{subsets}.
 #' @param subsets Optional vector of covariates to bin data by.
 #' Breaks between bins are the empirical quantiles of
-#' \code{subsets} bu default or all unique factors or charater strings.
+#' \code{subsets} by default or all unique factors or charater strings.
 #' Cannot be used with \code{kfolds}.
-#' @param breaks Number of quantiles to divide subsets by, results
-#' in \code{breaks+1} bins, or is length > 1, a vector of break points.
+#' @param breaks Either the number of quantiles to use to bin \code{subsets} by (resulting
+#' in \code{breaks+1} bins, defaults to \code{breaks=4}), or, if \code{length(breaks) > 1}, a vector of spcific break
+#' points. \code{subsets} must be provided.
 #' @param bootstrap Calculate this number of boostrap samples
 #' to estimate 95\% confdence interval
 #' @param plot.it \code{boolean}. Make a plot?

--- a/man/pinball.Rd
+++ b/man/pinball.Rd
@@ -8,10 +8,10 @@ pinball(
   qrdata,
   realisations,
   kfolds = NULL,
-  plot.it = T,
   subsets = NULL,
   breaks = 4,
   bootstrap = NULL,
+  plot.it = T,
   ...
 )
 }
@@ -24,13 +24,19 @@ pinball(
 \item{kfolds}{Optional vector of fold/test labels corresponding to rows of \code{qrdata}.
 Cannot be used with \code{subsets}.}
 
-\item{plot.it}{\code{boolean}. Make a plot?}
+\item{subsets}{Optional vector of covariates to bin data by.
+Breaks between bins are the empirical quantiles of
+\code{subsets} by default or all unique factors or charater strings. Custom
+breaks may be specifed, see \code{breaks}.
+Cannot be used with \code{kfolds}.}
 
-\item{subsets}{Covariate to subset evaluation metric by corresponding to rows of \code{qrdata}.}
-
-\item{breaks}{number of subsets to form.}
+\item{breaks}{Either the number of quantiles to use to bin \code{subsets} by (resulting
+in \code{breaks+1} bins, defaults to \code{breaks=4}), or, if \code{length(breaks) > 1}, a vector of spcific break
+points. Only used if \code{subsets} provided.}
 
 \item{bootstrap}{Number of boostrap samples used to generate 95\% confidence intervals.}
+
+\item{plot.it}{\code{boolean}. Make a plot?}
 
 \item{...}{Additional arguments passed to \code{plot()}.}
 }
@@ -38,9 +44,10 @@ Cannot be used with \code{subsets}.}
 Quantile Score data and, if \code{plot.it=T}, a plot.
 }
 \description{
-This function calculates the pinball score for each quantile in a \code{MultiQR}
-object. Optionally, results are produced by cross-validation fold or covariate,
-95\% confidence intervals are estimated via bootstrap, and results are plotted.
+This function calculates the pinball score for each quantile in a
+\code{MultiQR} object. Optionally, results are produced by cross-validation fold
+or covariate, 95\% confidence intervals are estimated via bootstrap, and results
+are plotted.
 }
 \details{
 Missing values in \code{realisations} are handled by \code{na.rm=T} when

--- a/man/qreg_gam.Rd
+++ b/man/qreg_gam.Rd
@@ -9,7 +9,7 @@ qreg_gam(
   formula,
   formula_qr = NULL,
   model_res2 = F,
-  formula_res2 = formula,
+  formula_res2 = NULL,
   quantiles = c(0.25, 0.5, 0.75),
   cv_folds = NULL,
   use_bam = T,

--- a/man/reliability.Rd
+++ b/man/reliability.Rd
@@ -26,10 +26,11 @@ to rows of \code{qrdata}. Cannot be used with \code{subsets}.}
 
 \item{subsets}{Optional vector of covariates to bin data by.
 Breaks between bins are the empirical quantiles of
-\code{subsets}. Cannot be used with \code{kfolds}.}
+\code{subsets} bu default or all unique factors or charater strings.
+Cannot be used with \code{kfolds}.}
 
 \item{breaks}{Number of quantiles to divide subsets by, results
-in \code{breaks+1} bins.}
+in \code{breaks+1} bins, or is length > 1, a vector of break points.}
 
 \item{bootstrap}{Calculate this number of boostrap samples
 to estimate 95\% confdence interval}

--- a/man/reliability.Rd
+++ b/man/reliability.Rd
@@ -26,11 +26,12 @@ to rows of \code{qrdata}. Cannot be used with \code{subsets}.}
 
 \item{subsets}{Optional vector of covariates to bin data by.
 Breaks between bins are the empirical quantiles of
-\code{subsets} bu default or all unique factors or charater strings.
+\code{subsets} by default or all unique factors or charater strings.
 Cannot be used with \code{kfolds}.}
 
-\item{breaks}{Number of quantiles to divide subsets by, results
-in \code{breaks+1} bins, or is length > 1, a vector of break points.}
+\item{breaks}{Either the number of quantiles to use to bin \code{subsets} by (resulting
+in \code{breaks+1} bins, defaults to \code{breaks=4}), or, if \code{length(breaks) > 1}, a vector of spcific break
+points. \code{subsets} must be provided.}
 
 \item{bootstrap}{Calculate this number of boostrap samples
 to estimate 95\% confdence interval}

--- a/man/reliability.Rd
+++ b/man/reliability.Rd
@@ -26,15 +26,16 @@ to rows of \code{qrdata}. Cannot be used with \code{subsets}.}
 
 \item{subsets}{Optional vector of covariates to bin data by.
 Breaks between bins are the empirical quantiles of
-\code{subsets} by default or all unique factors or charater strings.
+\code{subsets} by default or all unique factors or charater strings. Custom
+breaks may be specifed, see \code{breaks}.
 Cannot be used with \code{kfolds}.}
 
 \item{breaks}{Either the number of quantiles to use to bin \code{subsets} by (resulting
 in \code{breaks+1} bins, defaults to \code{breaks=4}), or, if \code{length(breaks) > 1}, a vector of spcific break
+points. Only used if \code{subsets} provided.
 points. \code{subsets} must be provided.}
 
-\item{bootstrap}{Calculate this number of boostrap samples
-to estimate 95\% confdence interval}
+\item{bootstrap}{Number of boostrap samples used to generate 95\% confidence intervals.}
 
 \item{plot.it}{\code{boolean}. Make a plot?}
 


### PR DESCRIPTION
Lets user to specify break points when sub-setting data for evaluation. Also allows for subset by factors in reliability now (was already in pinball). Addresses issue #45 raised by @rosemary-t. 

![default_break](https://user-images.githubusercontent.com/32899312/116093520-a6e4fb00-a69e-11eb-85a8-bdb17ed2e96b.png)
![custom_break](https://user-images.githubusercontent.com/32899312/116093524-a77d9180-a69e-11eb-8e96-c39b9a06ff67.png)
