### PR TITLE
New option for tail extrapolation.

### DIFF
--- a/R/contCDF.R
+++ b/R/contCDF.R
@@ -33,7 +33,9 @@
 #' via \code{thicknessPL} and \code{thicknessPR}. The number
 #' of tail quantiles to be estimated is set by \code{ntailpoints}, which defaults to 5.
 #' Alternatively \code{tails=list(method="exponential",thickparamFunc)} where \code{thickparamFunc}
-#' is a function that takes the q50 as an input and returns the thickness parameter.
+#' is a function that takes the q50 as an input and returns the thickness parameter. If \code{method="extrapolate_dtail2"} then
+#' tails are extrapolated to the highest quantile in \code{quantiles} plus \code{U} and the lowest quantile in \code{quantiles} 
+#' plus (\code{L}). Note that for both alternative options, \code{U} should be positive and \code{L} should be negative.
 #' 
 #' Dynamic exponential tails: \code{tails=list(method="dyn_exponential",ntailpoints=5)}, where the tail shape
 #' is conditional on the values for the upper and lower quantile of \code{qrdata}. This method 
@@ -68,6 +70,11 @@ contCDF <- function(quantiles,kfold=NULL,inverse=F,
     Lquants <- quantiles[which(Probs==0.5)] + tails$L
     RnomP <- 1
     Rquants <- quantiles[which(Probs==0.5)] + tails$U
+  }else if(tails$method=="interpolate_dtail2" | tails$method=="extrapolate_dtail2"){
+    LnomP <- 0
+    Lquants <- quantiles[which(Probs==min(Probs))] + tails$L
+    RnomP <- 1
+    Rquants <- quantiles[which(Probs==max(Probs))] + tails$U
   }else if(tails$method=="exponential"){
     
     if(!is.null(tails$thicknessPL) & !is.null(tails$thicknessPR)){


### PR DESCRIPTION
This adds another option for extrapolating the tails of the CDF. It takes the most extreme quantiles and bounds the CDF at a fixed interval above the maximum and below the minimum.
LIke the existing methods, it will require the L is a negative number.