### PR TITLE
Bug fix for floating point tolerance mismatches when assigning width.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,8 @@ Depends: R (>= 3.5.0),
 	fst (>= 0.9.4),
 	evgam (>= 0.1.2),
 	mgcv (>= 1.8),
-	quantreg (>= 5.0)
+	quantreg (>= 5.0),
+	dplyr
 Imports: gbm (>= 2.1.0)
 License: file LICENSE
 Encoding: UTF-8

--- a/R/sharpness.R
+++ b/R/sharpness.R
@@ -56,7 +56,7 @@ sharpness <- function(qrdata,kfolds=NULL,bootstrap=NULL,...){
     
     
     } else{
-      SRP$Width[which(int==(1-q*2))] <- mean((qrdata[[paste0("q",100*(1-q))]]-qrdata[[paste0("q",100*q)]]),
+      SRP$Width[which(near(int, (1-q*2)))] <- mean((qrdata[[paste0("q",100*(1-q))]]-qrdata[[paste0("q",100*q)]]),
                                              na.rm = T)
     
     


### PR DESCRIPTION
This uses dplyr's near function to address an issue where R wasn't matching intervals, which meant the sharpness function was returning NA.
So, `which(int==1-q*2)) ` becomes `which(near(int, (1-q*2)))`.
Note that I haven't edited lines like this:
`which(qs==q)`
In this case, I believe `q` is always an element from the `qs` vector so I'd expect this to be fine (and haven't seen any issue myself).