### PR TITLE
Inverse cdf

### DIFF
--- a/R/contCDF.R
+++ b/R/contCDF.R
@@ -53,7 +53,8 @@
 #' @export
 contCDF <- function(quantiles,kfold=NULL,inverse=F,
                     method=list(name="spline",splinemethod="monoH.FC"),
-                    tails=list(method="extrapolate",L=0,U=1),...){
+                    tails=list(method="extrapolate",L=0,U=1),
+                    force_inverse=F, ...){
   
   ### Quantiles
   if(nrow(quantiles)!=1){stop("quantiles must be a single-row MultiQR object.")}


### PR DESCRIPTION
This forces consistency between a CDF and its inverse. It does this by evaluating the CDF spline function, and then fitting a spline function to these evaluated points with x and y swapped, and using this as the inverse. 
A function argument force_inverse is used, with a default of `FALSE`, for backwards compatability.
![image](https://user-images.githubusercontent.com/45767817/137126274-55597084-5082-4dca-b94c-cfb3084d5ee5.png)
